### PR TITLE
feat: add an api to fetch current price

### DIFF
--- a/src/component/formatter.ts
+++ b/src/component/formatter.ts
@@ -1,4 +1,5 @@
-import { Cell, HexString } from "@ckb-lumos/base";
+import { Cell, HexString, Output } from "@ckb-lumos/base";
+import { contracts } from '../config';
 
 export interface DexOrderData {
   sUDTAmount: bigint;
@@ -113,5 +114,14 @@ export class CkbUtils {
 
     const dataHex = udtAmountHex + orderAmountHex + priceHex + isBidHex;
     return dataHex;
+  }
+
+  static isOrder(type: { code_hash: string, hash_type: 'data' | 'type', args: string }, output: Output): boolean {
+    return output.type
+      && output.lock.code_hash === contracts.orderLock.codeHash
+      && output.lock.hash_type === contracts.orderLock.hashType
+      && output.type.code_hash === type.code_hash
+      && output.type.hash_type === type.hash_type
+      && output.type.args === type.args
   }
 }

--- a/src/modules/indexer/indexer.ts
+++ b/src/modules/indexer/indexer.ts
@@ -1,11 +1,12 @@
-import { Cell, QueryOptions, TransactionWithStatus } from "@ckb-lumos/base";
+import { Cell, QueryOptions, TransactionWithStatus, Transaction } from "@ckb-lumos/base";
 import {
   Indexer,
   CellCollector,
   TransactionCollector,
 } from "@ckb-lumos/indexer";
 import { injectable } from "inversify";
-import { indexer_config } from "../../config";
+import { indexer_config, contracts } from "../../config";
+import { DexOrderData, CkbUtils } from '../../component';
 import { IndexerService } from './indexer_service';
 
 
@@ -43,5 +44,56 @@ export default class IndexerWrapper implements IndexerService {
     for await (const tx of transactionCollector.collect()) txs.push(tx);
 
     return txs;
+  }
+
+  async getLastMatchOrders(
+    type: { code_hash: string, args: string, hash_type: 'data' | 'type' }
+  ): Promise<Record<'ask_orders' | 'bid_orders', Array<DexOrderData>> | null> {
+    const transactionCollector = new TransactionCollector(
+      this.indexer,
+      {
+        type,
+        lock: {
+          script: {
+            code_hash: contracts.orderLock.codeHash,
+            hash_type: contracts.orderLock.hashType,
+            args: "0x",
+          },
+          argsLen: 'any'
+        },
+        order: "desc",
+      },
+    );
+
+    for await (const { tx_status, transaction } of transactionCollector.collect() as any) {
+      if (tx_status.status === 'committed') {
+        const bid_orders: Array<DexOrderData> = [];
+        const ask_orders: Array<DexOrderData> = [];
+        const { outputs, outputs_data } = transaction as Transaction;
+        await Promise.all(outputs.map(async (output, idx) => {
+          if (CkbUtils.isOrder(type, output)) {
+            try {
+              const order = CkbUtils.parseOrderData(outputs_data[idx]);
+              if (order.orderAmount === 0n) {
+                // TODO: use order history to verify if the order is a REAL ONE
+                // const historyService = container.get<OrdersHistoryService>(modules[OrdersHistoryService.name])
+                // const history = await historyService.getOrderHistory(
+                //   output.type.code_hash,
+                //   output.type.hash_type,
+                //   output.type.args,
+                //   output.lock.args);
+                (order.isBid ? bid_orders : ask_orders).push(order);
+              }
+            } catch {
+              // ignore
+            }
+          }
+        }))
+        if (ask_orders.length && bid_orders.length) {
+          return { ask_orders, bid_orders };
+        }
+      }
+    }
+    return null;
   }
 }

--- a/src/modules/indexer/indexer_service.ts
+++ b/src/modules/indexer/indexer_service.ts
@@ -1,6 +1,10 @@
 import { Cell, QueryOptions, TransactionWithStatus } from '@ckb-lumos/base';
+import { DexOrderData } from '../../component'
 
 export interface IndexerService {
     collectCells(queryOptons: QueryOptions): Promise<Array<Cell>>;
     collectTransactions(queryOptions: QueryOptions): Promise<Array<TransactionWithStatus>>
+    getLastMatchOrders(
+        type: { code_hash: string, args: string, hash_type: 'data' | 'type' }
+    ): Promise<Record<'ask_orders' | 'bid_orders', Array<DexOrderData> | null>>
 }

--- a/src/modules/orders/orders_controller.ts
+++ b/src/modules/orders/orders_controller.ts
@@ -53,12 +53,6 @@ export default class OrderController {
           required: true,
           description: "",
         },
-        order_lock_args: {
-          name: "order_lock_args",
-          type: "string",
-          required: true,
-          description: "",
-        },
       },
     },
     responses: {
@@ -100,6 +94,56 @@ export default class OrderController {
         bid_orders: bid_orders.sort((o1, o2) => Number(BigInt(o1.price) - BigInt(o2.price))).slice(0, 10),
         ask_orders: ask_orders.sort((o1, o2) => Number(BigInt(o2.price) - BigInt(o1.price))).slice(0, 10),
       });
+    } catch (err) {
+      console.error(err);
+      res.status(500).send();
+    }
+  }
+  
+  @ApiOperationGet({
+    path: "current price",
+    description: "Get current price",
+    summary: "Get current price",
+    parameters: {
+      query: {
+        type_code_hash: {
+          name: "type_code_hash",
+          type: "string",
+          required: true,
+          description: "",
+        },
+        type_hash_type: {
+          name: "type_hash_type",
+          type: "string",
+          required: true,
+          description: "",
+        },
+        type_args: {
+          name: "type_args",
+          type: "string",
+          required: true,
+          description: "",
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Success",
+        type: SwaggerDefinitionConstant.Response.Type.STRING,
+      },
+      400: { description: "Parameters fail" },
+    },
+  })
+  @httpGet("current-price")
+  async getCurrentPrice(req: express.Request, res: express.Response): Promise<void> {
+    const {
+      type_code_hash: code_hash,
+      type_hash_type: hash_type,
+      type_args: args,
+    } = req.query as Record<string, any>;
+    try {
+      const price = await this.orderService.getCurrentPrice({ code_hash, hash_type, args })
+      res.status(200).json(price);
     } catch (err) {
       console.error(err);
       res.status(500).send();

--- a/src/modules/orders/orders_service.ts
+++ b/src/modules/orders/orders_service.ts
@@ -40,6 +40,16 @@ export default class OrdersService {
     return CkbUtils.formatOrderCells(orderCells.filter(o => o.data.length === REQUIRED_DATA_LENGTH));
   }
 
+  async getCurrentPrice(type: { code_hash: string, args: string, hash_type: 'data' | 'type' }): Promise<string> {
+    const orders = await this.indexer.getLastMatchOrders(type);
+    if (!orders) {
+      return '';
+    }
+    const bid_price = new BigNumber(orders.bid_orders.sort((o1, o2) => Number(o1.price - o2.price))[0].price.toString());
+    const ask_price = new BigNumber(orders.ask_orders.sort((o1, o2) => Number(o2.price - o1.price))[0].price.toString());
+    return (bid_price.plus(ask_price)).dividedBy(2).toString();
+  }
+
   async getBestPrice(
     type_code_hash,
     type_hash_type,

--- a/src/test/balance_controller.spec.ts
+++ b/src/test/balance_controller.spec.ts
@@ -103,6 +103,9 @@ describe('Balance controller', () => {
       collectTransactions(queryOptions: QueryOptions): Promise<TransactionWithStatus[]> {
         return null;
       }
+      getLastMatchOrders(type) {
+        return null;
+      }
   
     }
   

--- a/src/test/cells_controller.spec.ts
+++ b/src/test/cells_controller.spec.ts
@@ -83,6 +83,9 @@ describe('Cells controller', () => {
       collectTransactions(queryOptions: QueryOptions): Promise<TransactionWithStatus[]> {
         return null;
       }
+      getLastMatchOrders(type) {
+        return null;
+      }
   
     }
   


### PR DESCRIPTION
This commit adds an api to fetch current price, empty string should be returned when there're no orders matched.